### PR TITLE
[dash] Initialize dash trusted vni sai api

### DIFF
--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -247,6 +247,7 @@ void initSaiApi()
     sai_api_query((sai_api_t)SAI_API_DASH_TUNNEL,               (void**)&sai_dash_tunnel_api);
     sai_api_query((sai_api_t)SAI_API_DASH_HA,                   (void**)&sai_dash_ha_api);
     sai_api_query((sai_api_t)SAI_API_DASH_OUTBOUND_PORT_MAP,    (void**)&sai_dash_outbound_port_map_api);
+    sai_api_query((sai_api_t)SAI_API_DASH_TRUSTED_VNI,          (void**)&sai_dash_trusted_vni_api);
     sai_api_query(SAI_API_TWAMP,                (void **)&sai_twamp_api);
     sai_api_query(SAI_API_TAM,                  (void **)&sai_tam_api);
     sai_api_query(SAI_API_STP,                  (void **)&sai_stp_api);

--- a/tests/mock_tests/ut_saihelper.cpp
+++ b/tests/mock_tests/ut_saihelper.cpp
@@ -139,6 +139,7 @@ namespace ut_helper
         sai_dash_direction_lookup_api = nullptr;
         sai_dash_eni_api = nullptr;
         sai_dash_ha_api = nullptr;
+        sai_dash_trusted_vni_api = nullptr;
         sai_stp_api = nullptr;
 
         return SAI_STATUS_SUCCESS;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Initialized SAI API for SAI_API_DASH_TRUSTED_VNI in swss, which is required in dashorch.cpp for configuring trusted VNIs for [dash_appliance](https://github.com/sonic-net/sonic-swss/blob/392f1aa4a0007acdf5c91c354b0acbdb850f7f1d/orchagent/dash/dashorch.cpp#L251) and [dash_enis](https://github.com/sonic-net/sonic-swss/blob/392f1aa4a0007acdf5c91c354b0acbdb850f7f1d/orchagent/dash/dashorch.cpp#L752)

**Why I did it**
This was done because if the SAI API is not initialized, then we see an orchagent crash when trusted vni is configured on the device since the api pointer is initialized to null. On configuration of hte below object over gnmi:
```
 "DASH_APPLIANCE_TABLE:100": {
            "sip": "10.1.0.5",
            "vm_vni": "4321",
            "local_region_id": "100",
            "outbound_direction_lookup": "src_mac",
            "trusted_vnis": {
                "value": 100
             }
        },
```
```
2025 Jul 23 19:51:56.348643 sonic NOTICE swss#orchagent: :- addApplianceEntry: Created appliance, vip and direction lookup entries for 100
2025 Jul 23 19:51:58.247761 sonic INFO swss#supervisord 2025-07-23 19:51:58,246 WARN exited: orchagent (terminated by SIGSEGV (core dumped); not expected)
2025 Jul 23 19:51:59.251115 sonic INFO swss#supervisor-proc-exit-listener: Process 'orchagent' exited unexpectedly. Terminating supervisor 'swss'
```

**How I verified it**
Configure the dash object with trusted vnis, observe that orchagent doesnt crash with seg-fault

**Details if related**
