### PR TITLE
Respect Cargo.lock for dependencies version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1347,7 +1347,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 [[package]]
 name = "swss-common"
 version = "0.1.0"
-source = "git+https://github.com/sonic-net/sonic-swss-common.git?branch=master#1484a851dbfdd4b122c361cd7ea03eca0afe5d63"
+source = "git+https://github.com/sonic-net/sonic-swss-common.git?branch=master#16a8a937f6726bfa2309fc4b78b1c7e1d86594dd"
 dependencies = [
  "bindgen",
  "getset",

--- a/debian/rules
+++ b/debian/rules
@@ -38,14 +38,11 @@ endif
 
 override_dh_auto_configure:
 	dh_auto_configure -- $(configure_opts)
-	# Configure Rust build for countersyncd
-	cargo fetch
-	cargo update -p swss-common
 
 override_dh_auto_build:
 	dh_auto_build
 	# Build and test countersyncd Rust project
-	cargo build --release
+	cargo build --release --locked
 
 override_dh_auto_install:
 	dh_auto_install --destdir=debian/swss


### PR DESCRIPTION
Why I did it
Currently cargo update will update dependencies in the Cargo.lock file to the latest version on the specified branch. The sonic-swss-common Rust code is possibly not aligned with libswsscommon package, which will make sonic-buildimage build fail.

How I verified it
Verify local sonic-buildimage build passing, even there is sonic-swss-common changes on c-api.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
